### PR TITLE
Switch to using config struct for program configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/juju/testing v0.0.0-20200510222523-6c8c298c77a0
 	github.com/prometheus/alertmanager v0.20.0
 	github.com/prometheus/client_golang v1.6.0
+	github.com/prometheus/client_model v0.2.0
 )

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"os/signal"
 	"strconv"
 	"time"
 
@@ -17,101 +19,88 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
+const (
+	// Namespace for prometheus metrics produced by this program
+	metricNamespace = "am_executor"
+	// How long we are willing to wait for the HTTP server to shut down gracefully
+	serverShutdownTime = time.Second * 4
+)
+
 var (
-	listenAddr      = flag.String("l", ":8080", "HTTP Port to listen on")
-	verbose         = flag.Bool("v", false, "Enable verbose/debug logging")
-	processDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Namespace: "am_executor",
+	procDurationOpts = prometheus.HistogramOpts{
+		Namespace: metricNamespace,
 		Subsystem: "process",
 		Name:      "duration_seconds",
 		Help:      "Time the processes handling alerts ran.",
 		Buckets:   []float64{1, 10, 60, 600, 900, 1800},
-	})
+	}
 
-	processesCurrent = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: "am_executor",
+	procCurrentOpts = prometheus.GaugeOpts{
+		Namespace: metricNamespace,
 		Subsystem: "processes",
 		Name:      "current",
 		Help:      "Current number of processes running.",
-	})
+	}
 
-	errCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: "am_executor",
+	errCountOpts = prometheus.CounterOpts{
+		Namespace: metricNamespace,
 		Subsystem: "errors",
 		Name:      "total",
 		Help:      "Total number of errors while processing alerts.",
-	}, []string{"stage"})
+	}
 
-	rnr *runner
+	errCountLabels = []string{"stage"}
 )
 
-func handleError(w http.ResponseWriter, err error) {
-	http.Error(w, err.Error(), http.StatusInternalServerError)
-	log.Println(err)
+// Represent the configuration for this program
+type config struct {
+	listenAddr      string
+	verbose         bool
+	processDuration prometheus.Histogram
+	processCurrent  prometheus.Gauge
+	errCounter      *prometheus.CounterVec
+	command         string
+	args            []string
 }
 
-func handleWebhook(w http.ResponseWriter, req *http.Request) {
-	if *verbose {
+// handleWebhook is meant to respond to webhook requeests from prometheus alert manager.
+// It unpacks the alert payload, and passes the information to the program specified in its configuration.
+func (c *config) handleWebhook(w http.ResponseWriter, req *http.Request) {
+	if c.verbose {
 		log.Println("Webhook triggered")
 	}
 	data, err := ioutil.ReadAll(req.Body)
 	if err != nil {
 		handleError(w, err)
-		errCounter.WithLabelValues("read")
+		c.errCounter.WithLabelValues("read").Inc()
 		return
 	}
-	if *verbose {
+
+	if c.verbose {
 		log.Println("Body:", string(data))
 	}
 	payload := &template.Data{}
 	if err := json.Unmarshal(data, payload); err != nil {
 		handleError(w, err)
-		errCounter.WithLabelValues("unmarshal")
+		c.errCounter.WithLabelValues("unmarshal").Inc()
 	}
-	if *verbose {
+	if c.verbose {
 		log.Printf("Got: %#v", payload)
 	}
-	if err := rnr.run(amDataToEnv(payload)); err != nil {
+
+	c.processCurrent.Inc()
+	start := time.Now()
+	err = run(c.command, c.args, amDataToEnv(payload))
+	c.processDuration.Observe(time.Since(start).Seconds())
+	c.processCurrent.Dec()
+	if err != nil {
 		handleError(w, err)
-		errCounter.WithLabelValues("start")
+		c.errCounter.WithLabelValues("start").Inc()
 	}
 }
 
-func handleHealth(w http.ResponseWriter, req *http.Request) {
-	fmt.Fprint(w, "All systems are functioning within normal specifications.\n")
-}
-
-type logWriter struct{}
-
-func (lw *logWriter) Write(p []byte) (n int, err error) {
-	log.Print(string(p))
-	return len(p), nil
-}
-
-type runner struct {
-	command   string
-	args      []string
-	processes []exec.Cmd
-}
-
-func (r *runner) run(env []string) error {
-	lw := &logWriter{}
-	processesCurrent.Inc()
-	defer processesCurrent.Dec()
-	cmd := exec.Command(r.command, r.args...)
-	cmd.Env = append(os.Environ(), env...)
-	cmd.Stdout = lw
-	cmd.Stderr = lw
-	return cmd.Run()
-}
-
-func timeToStr(t time.Time) string {
-	if t.IsZero() {
-		return "0"
-	}
-	return strconv.Itoa(int(t.Unix()))
-}
-
+// amDataToEnv converts prometheus alert manager template data into key=value strings,
+// which are meant to be set as environment variables of commands called by this program..
 func amDataToEnv(td *template.Data) []string {
 	env := []string{
 		"AMX_RECEIVER=" + td.Receiver,
@@ -149,28 +138,133 @@ func amDataToEnv(td *template.Data) []string {
 	return env
 }
 
-func main() {
-	prometheus.MustRegister(processDuration)
-	prometheus.MustRegister(processesCurrent)
-	prometheus.MustRegister(errCounter)
-	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: %s [options] script [args..]\n\n", os.Args[0])
-		flag.PrintDefaults()
+// handleError responds to an HTTP request with an error message and logs it
+func handleError(w http.ResponseWriter, err error) {
+	http.Error(w, err.Error(), http.StatusInternalServerError)
+	log.Println(err)
+}
+
+// handleHealth is meant to respond to health checks for this program
+func handleHealth(w http.ResponseWriter, req *http.Request) {
+	_, err := fmt.Fprint(w, "All systems are functioning within normal specifications.\n")
+	if err != nil {
+		handleError(w, err)
 	}
+}
+
+// readCli parses cli flags and populates them in config
+func readCli(c *config) error {
+	flag.StringVar(&c.listenAddr, "l", ":8080", "HTTP Port to listen on")
+	flag.BoolVar(&c.verbose, "v", false, "Enable verbose/debug logging")
 	flag.Parse()
-	command := flag.Args()
-	if len(command) == 0 {
-		log.Fatal("Require command")
+	args := flag.Args()
+	if len(args) == 0 {
+		return fmt.Errorf("Missing command to execute on receipt of alarm")
 	}
-	rnr = &runner{
-		command: command[0],
+
+	c.command = args[0]
+	if len(args) > 1 {
+		c.args = args[1:]
 	}
-	if len(command) > 1 {
-		rnr.args = command[1:]
+
+	return nil
+}
+
+// readConfig reads config from supported means (cli flags, config file), and returns a config struct for this program.
+// Cli flags will overwrite settings in the config file.
+func readConfig() (*config, error) {
+	c := config{}
+	err := readCli(&c)
+	if err != nil {
+		flag.Usage()
 	}
-	http.HandleFunc("/", handleWebhook)
+
+	c.processDuration = prometheus.NewHistogram(procDurationOpts)
+	c.processCurrent = prometheus.NewGauge(procCurrentOpts)
+	c.errCounter = prometheus.NewCounterVec(errCountOpts, errCountLabels)
+
+	return &c, err
+}
+
+// run executes the given command with the given environment, and attaches its STDOUT and STDERR to the logger.
+func run(name string, args []string, env []string) error {
+	lw := log.Writer()
+	cmd := exec.Command(name, args...)
+	cmd.Env = append(os.Environ(), env...)
+	cmd.Stdout = lw
+	cmd.Stderr = lw
+	return cmd.Run()
+}
+
+// serve starts the golang http server with the given routes, and returns
+// a reference to the HTTP server (so that one could gracefully shut it down), and
+// a channel that will contain the error result of the ListenAndServe call
+func serve(c *config) (*http.Server, chan error) {
+	prometheus.MustRegister(c.processDuration)
+	prometheus.MustRegister(c.processCurrent)
+	prometheus.MustRegister(c.errCounter)
+
+	// Use DefaultServeMux as the handler
+	srv := &http.Server{Addr: c.listenAddr, Handler: nil}
+	http.HandleFunc("/", c.handleWebhook)
 	http.HandleFunc("/_health", handleHealth)
 	http.Handle("/metrics", promhttp.Handler())
-	log.Println("Listening on", *listenAddr, "and running", command)
-	log.Fatal(http.ListenAndServe(*listenAddr, nil))
+
+	// Start http server in a goroutine, so that it doesn't block other activities
+	var httpSrvResult = make(chan error)
+	go func() {
+		err := srv.ListenAndServe()
+		log.Println("Listening on", c.listenAddr, "with command", c.command)
+		httpSrvResult <- err
+	}()
+
+	return srv, httpSrvResult
+}
+
+// timeToStr converts the Time struct into a string representing its Unix epoch.
+func timeToStr(t time.Time) string {
+	if t.IsZero() {
+		return "0"
+	}
+	return strconv.Itoa(int(t.Unix()))
+}
+
+func init() {
+	// Customize the flag.Usage function's output
+	flag.Usage = func() {
+		_, _ = fmt.Fprintf(os.Stderr, "Usage: %s [options] script [args..]\n\n", os.Args[0])
+		flag.PrintDefaults()
+	}
+}
+
+func main() {
+	// Determine configuration for service
+	c, err := readConfig()
+	if err != nil {
+		log.Fatalf("Couldn't determine configuration: %v", err)
+	}
+
+	// Listen for signals telling us to stop
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, os.Interrupt)
+
+	// Start the http server
+	srv, srvResult := serve(c)
+
+	select {
+	case err := <-srvResult:
+		if err != nil {
+			log.Fatalf("Failed to serve for %s: %v", c.listenAddr, err)
+		} else {
+			log.Println("HTTP server shut down")
+		}
+	case s := <-signals:
+		log.Println("Shutting down due to signal:", s)
+		ctx, cancel := context.WithTimeout(context.Background(), serverShutdownTime)
+		defer cancel()
+		err := srv.Shutdown(ctx)
+		if err != nil {
+			log.Printf("Failed to shut down HTTP server: %v", err)
+		}
+	}
 }

--- a/main.go
+++ b/main.go
@@ -83,6 +83,7 @@ func (c *config) handleWebhook(w http.ResponseWriter, req *http.Request) {
 	if err := json.Unmarshal(data, payload); err != nil {
 		handleError(w, err)
 		c.errCounter.WithLabelValues("unmarshal").Inc()
+		return
 	}
 	if c.verbose {
 		log.Printf("Got: %#v", payload)

--- a/main_test.go
+++ b/main_test.go
@@ -1,52 +1,63 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
 	"log"
+	"net"
+	"net/http/httptest"
 	"sort"
 	"testing"
 	"time"
 
 	"github.com/juju/testing/checkers"
 	"github.com/prometheus/alertmanager/template"
+	"github.com/prometheus/client_golang/prometheus"
+	pm "github.com/prometheus/client_model/go"
 )
 
 var (
-	amDataToEnvMap = map[*template.Data][]string{
-		&template.Data{
-			Receiver: "default", Status: "firing", Alerts: template.Alerts{
-				template.Alert{Status: "firing", Labels: template.KV{
-					"job":       "broken",
-					"monitor":   "codelab-monitor",
-					"alertname": "InstanceDown",
-					"instance":  "localhost:1234",
-				},
-					Annotations:  template.KV{},
-					StartsAt:     time.Unix(1460045332, 0),
-					EndsAt:       time.Time{},
-					GeneratorURL: "http://oldpad:9090/graph#%5B%7B%22expr%22%3A%22up%20%3D%3D%200%22%2C%22tab%22%3A0%7D%5D",
-				},
-				template.Alert{Status: "firing", Labels: template.KV{
-					"job":       "broken",
-					"monitor":   "codelab-monitor",
-					"alertname": "InstanceDown",
-					"instance":  "localhost:5678",
-				},
-					Annotations:  template.KV{},
-					StartsAt:     time.Unix(1460045332, 0),
-					EndsAt:       time.Time{},
-					GeneratorURL: "http://oldpad:9090/graph#%5B%7B%22expr%22%3A%22up%20%3D%3D%200%22%2C%22tab%22%3A0%7D%5D",
-				},
-			},
-			GroupLabels: template.KV{"alertname": "InstanceDown"},
-			CommonLabels: template.KV{
-				"alertname": "InstanceDown",
-				"instance":  "localhost:1234",
+	// A sample alert from prometheus alert manager
+	alertManagerData = template.Data{
+		Receiver: "default", Status: "firing", Alerts: template.Alerts{
+			template.Alert{Status: "firing", Labels: template.KV{
 				"job":       "broken",
 				"monitor":   "codelab-monitor",
+				"alertname": "InstanceDown",
+				"instance":  "localhost:1234",
 			},
-			CommonAnnotations: template.KV{},
-			ExternalURL:       "http://oldpad:9093",
-		}: []string{
+				Annotations:  template.KV{},
+				StartsAt:     time.Unix(1460045332, 0),
+				EndsAt:       time.Time{},
+				GeneratorURL: "http://oldpad:9090/graph#%5B%7B%22expr%22%3A%22up%20%3D%3D%200%22%2C%22tab%22%3A0%7D%5D",
+			},
+			template.Alert{Status: "firing", Labels: template.KV{
+				"job":       "broken",
+				"monitor":   "codelab-monitor",
+				"alertname": "InstanceDown",
+				"instance":  "localhost:5678",
+			},
+				Annotations:  template.KV{},
+				StartsAt:     time.Unix(1460045332, 0),
+				EndsAt:       time.Time{},
+				GeneratorURL: "http://oldpad:9090/graph#%5B%7B%22expr%22%3A%22up%20%3D%3D%200%22%2C%22tab%22%3A0%7D%5D",
+			},
+		},
+		GroupLabels: template.KV{"alertname": "InstanceDown"},
+		CommonLabels: template.KV{
+			"alertname": "InstanceDown",
+			"instance":  "localhost:1234",
+			"job":       "broken",
+			"monitor":   "codelab-monitor",
+		},
+		CommonAnnotations: template.KV{},
+		ExternalURL:       "http://oldpad:9093",
+	}
+
+	// A mapping of sample prometheus alert manager data, to the output we expect from the amDataToEnv function.
+	amDataToEnvMap = map[*template.Data][]string{
+		&alertManagerData: []string{
 			"AMX_ALERT_1_END=0",
 			"AMX_ALERT_1_LABEL_alertname=InstanceDown",
 			"AMX_ALERT_1_LABEL_instance=localhost:1234",
@@ -77,6 +88,57 @@ var (
 	}
 )
 
+// getCounterValue digs through nested prometheus structs to retrieve a metric's value
+func getCounterValue(cv *prometheus.CounterVec, labels ...string) (float64, error) {
+	c, err := cv.GetMetricWithLabelValues(labels...)
+	if err != nil {
+		return 0, err
+	}
+
+	var metric pm.Metric
+	err = c.Write(&metric)
+	if err != nil {
+		return 0, err
+	}
+
+	return metric.GetCounter().GetValue(), nil
+}
+
+// testConfig returns a test config for the prometheus-am-executor.
+func testConfig() (*config, error) {
+	addr, err := RandLoopAddr()
+	c := config{
+		listenAddr:      addr,
+		verbose:         false,
+		processDuration: prometheus.NewHistogram(procDurationOpts),
+		processCurrent:  prometheus.NewGauge(procCurrentOpts),
+		errCounter:      prometheus.NewCounterVec(errCountOpts, errCountLabels),
+		command:         "echo",
+	}
+
+	return &c, err
+}
+
+// RandLoopAddr returns an available loopback address and TCP port
+func RandLoopAddr() (string, error) {
+	// When port 0 is specified, net.ListenTCP will automatically choose a port
+	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	if err != nil {
+		return "", err
+	}
+
+	ln, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		return "", err
+	}
+
+	defer func() {
+		_ = ln.Close()
+	}()
+
+	return ln.Addr().String(), nil
+}
+
 func TestAmDataToEnv(t *testing.T) {
 	for td, expectedEnv := range amDataToEnvMap {
 		env := amDataToEnv(td)
@@ -86,5 +148,80 @@ func TestAmDataToEnv(t *testing.T) {
 		if ok, err := checkers.DeepEqual(env, expectedEnv); !ok {
 			log.Fatal(err)
 		}
+	}
+}
+
+func TestHandleWebhook(t *testing.T) {
+	payload, err := json.Marshal(&alertManagerData)
+	if err != nil {
+		t.Errorf("Failed to encode alertManagerData as JSON")
+	}
+
+	// Send a request to handleWebhook
+	req := httptest.NewRequest("GET", "/", bytes.NewReader(payload))
+	w := httptest.NewRecorder()
+
+	c, err := testConfig()
+	if err != nil {
+		t.Errorf("Failed to generate mock config")
+	}
+
+	c.handleWebhook(w, req)
+
+	// Check response of request
+	resp := w.Result()
+	if resp.StatusCode != 200 {
+		t.Errorf("Wrong response from handleWebhook; got %d, want %d", resp.StatusCode, 200)
+	}
+
+	// Check the process duration metric
+	var pdMetric pm.Metric
+	err = c.processDuration.Write(&pdMetric)
+	if err != nil {
+		t.Errorf("Failed to retrieve processDuration metric from handleWebhook: %v", err)
+	}
+	durationCount := pdMetric.GetHistogram().GetSampleCount()
+	if durationCount == 0 {
+		t.Errorf("handleWebhook didn't observe processDuration metric samples")
+	}
+
+	// Check the process count metric
+	var pcMetric pm.Metric
+	err = c.processCurrent.Write(&pcMetric)
+	if err != nil {
+		t.Errorf("Failed to retrieve processCurrent metric from handleWebhook: %v", err)
+	}
+	current := pcMetric.GetGauge().GetValue()
+	if current > 0 {
+		t.Errorf("handleWebhook metric says process is still running; got %f, want %d", current, 0)
+	}
+
+	// Check the error metrics
+	for _, label := range([]string{"read", "unmarshal", "start"}) {
+		count, err := getCounterValue(c.errCounter, label)
+		if err != nil {
+			t.Errorf("Failed to retrieve '%s' count from handleWebhook: %v", label, err)
+		} else if count > 0 {
+			t.Errorf("handleWebhook registered '%s' errors; got %f, want %d", label, count, 0)
+		}
+	}
+}
+
+func TestHandleHealth(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+
+	handleHealth(w, req)
+	resp := w.Result()
+	if resp.StatusCode != 200 {
+		t.Errorf("Wrong response from handleHealth; got %d, want %d", resp.StatusCode, 200)
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Errorf("Failed to read response from handleHealth: %v", err)
+	}
+	expected := "All systems are functioning within normal specifications.\n"
+	if string(body) != expected {
+		t.Errorf("Unexpected response body; got %s, want %s", string(body), expected)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -208,7 +208,7 @@ func TestHandleWebhook(t *testing.T) {
 }
 
 func TestHandleHealth(t *testing.T) {
-	req := httptest.NewRequest("GET", "/", nil)
+	req := httptest.NewRequest("GET", "/_health", nil)
 	w := httptest.NewRecorder()
 
 	handleHealth(w, req)


### PR DESCRIPTION
* resolves #18
* handleWebhook actually records prometheus metrics (available via the `/metrics` endpoint) for itself now
* Also add test cases for handleWebhook, handleHealth. resolves #19
    * Checks http responses
    * Check metrics observed by handleWebhook
* HTTP server can be stopped independently of program, so we have the option of running instances of it in test cases.
    * Test cases use a random available TCP port to bind to, HTTP if server is run
* Add signal-handling, to gracefully shut down HTTP server when program receives SIGINT (give existing requests 4 seconds to finish)
* Connect command stdout, stderr directly to log writer
* Don't attempt to execute the command, if we weren't able to decode prometheus alarm data properly