### PR TITLE
multi command support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - checkout
       - run:
-          name: "Run tests"
+          name: "Build a binary"
           command: make build
 
   test:
@@ -18,7 +18,7 @@ jobs:
     steps:
       - checkout
       - run:
-          name: "Build a binary"
+          name: "Run tests"
           command: make test
 
 workflows:

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ commands:
 |`args`|Optional arguments that you want to pass to the command|
 |`match_labels`|What alert labels you'd like to use, to determine if the command should be executed. **All** specified labels must match in order for the command to be executed. If `match_labels` isn't specified, the command will be executed for _all_ alerts.|
 
-In the above configuration example, `/bin/true` will be executed for all alerts, and `echo` will be executed when an alert has the labels `env="true"` and `owner="me"`.
+In the above configuration example, `/bin/true` will be executed for all alerts, and `echo` will be executed when an alert has the labels `env="testing"` and `owner="me"`.
 
 ## Example: Reboot systems with errors
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ If you'd like to check the behaviour of a configuration file when prometheus-am-
 ./prometheus-am-executor -f examples/executor.yml -v
 ```
 
-##### 2. Sent an alert to prometheus-am-executor
+##### 2. Send an alert to prometheus-am-executor
 
 Make sure the port used in the curl command matches whatever you specified.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ set:
 
 ### Using a configuration file
 
-If the `-f` flag is set, the program will read the given YAML file as configuration. Any settings specified at the cli take precedence over the same settings defined in a config file.
+If the `-f` flag is set, the program will read the given YAML file as configuration on startup. Any settings specified at the cli take precedence over the same settings defined in a config file.
 
 This feature is useful if you wish to configure prometheus-am-executor to dispatch to multiple processes based on what labels match between an alert and a command configuration.
 
@@ -89,6 +89,26 @@ commands:
 |`match_labels`|What alert labels you'd like to use, to determine if the command should be executed. **All** specified labels must match in order for the command to be executed. If `match_labels` isn't specified, the command will be executed for _all_ alerts.|
 
 In the above configuration example, `/bin/true` will be executed for all alerts, and `echo` will be executed when an alert has the labels `env="testing"` and `owner="me"`.
+
+#### Testing configuration file changes
+
+If you'd like to check the behaviour of a configuration file when prometheus-am-executor receives alerts, you can use the [curl](https://curl.haxx.se/) command to replay an alert. An example alert payload is [provided in the examples directory](examples/alert_payload.json).
+
+##### 1. Start prometheus-am-executor with your configuration file
+
+```
+./prometheus-am-executor -f examples/executor.yml -v
+```
+
+##### 2. Sent an alert to prometheus-am-executor
+
+Make sure the port used in the curl command matches whatever you specified.
+
+```
+curl --include -H 'Content-Type: application/json' --data-binary "@examples/alert_payload.json" -X GET 'http://localhost:23222/'
+```
+
+##### 3. Check the output of prometheus-am-executor
 
 ## Example: Reboot systems with errors
 

--- a/examples/alert_payload.json
+++ b/examples/alert_payload.json
@@ -1,0 +1,45 @@
+{
+  "receiver": "default",
+  "status": "firing",
+  "alerts": [
+    {
+      "status": "firing",
+      "labels": {
+        "alertname": "InstanceDown",
+        "instance": "localhost:1234",
+        "job": "broken",
+        "monitor": "codelab-monitor"
+      },
+      "annotations": {},
+      "startsAt": "2016-04-07T10:08:52-06:00",
+      "endsAt": "0001-01-01T00:00:00Z",
+      "generatorURL": "http://oldpad:9090/graph#%5B%7B%22expr%22%3A%22up%20%3D%3D%200%22%2C%22tab%22%3A0%7D%5D",
+      "fingerprint": ""
+    },
+    {
+      "status": "firing",
+      "labels": {
+        "alertname": "InstanceDown",
+        "instance": "localhost:5678",
+        "job": "broken",
+        "monitor": "codelab-monitor"
+      },
+      "annotations": {},
+      "startsAt": "2016-04-07T10:08:52-06:00",
+      "endsAt": "0001-01-01T00:00:00Z",
+      "generatorURL": "http://oldpad:9090/graph#%5B%7B%22expr%22%3A%22up%20%3D%3D%200%22%2C%22tab%22%3A0%7D%5D",
+      "fingerprint": ""
+    }
+  ],
+  "groupLabels": {
+    "alertname": "InstanceDown"
+  },
+  "commonLabels": {
+    "alertname": "InstanceDown",
+    "instance": "localhost:1234",
+    "job": "broken",
+    "monitor": "codelab-monitor"
+  },
+  "commonAnnotations": {},
+  "externalURL": "http://oldpad:9093"
+}

--- a/examples/executor.yml
+++ b/examples/executor.yml
@@ -1,0 +1,12 @@
+---
+listen_address: ":23222"
+verbose: false
+commands:
+  - cmd: echo
+    args: ["banana", "tomato"]
+    match_labels:
+      "env": "testing"
+      "owner": "me"
+  - cmd: /bin/true
+    match_labels:
+      "beep": "boop"

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,5 @@ require (
 	github.com/prometheus/alertmanager v0.20.0
 	github.com/prometheus/client_golang v1.6.0
 	github.com/prometheus/client_model v0.2.0
+	gopkg.in/yaml.v2 v2.2.5
 )

--- a/main_test.go
+++ b/main_test.go
@@ -529,7 +529,7 @@ commands:
 		t.Errorf("Wrong ListenAddr for merged config; got %s, want %s", mergedAgain.ListenAddr, yamlConf.ListenAddr)
 	}
 	if mergedAgain.Verbose != (merged.Verbose || yamlConf.Verbose) {
-		t.Errorf("Wrong Verbose for merged config; got %v, want %v", mergedAgain.Verbose, yamlConf.Verbose)
+		t.Errorf("Wrong Verbose for merged config; got %v, want %v", mergedAgain.Verbose, (merged.Verbose || yamlConf.Verbose))
 	}
 
 	allCmds = append(allCmds, yamlConf.Commands...)

--- a/main_test.go
+++ b/main_test.go
@@ -528,7 +528,7 @@ commands:
 	if mergedAgain.ListenAddr != yamlConf.ListenAddr {
 		t.Errorf("Wrong ListenAddr for merged config; got %s, want %s", mergedAgain.ListenAddr, yamlConf.ListenAddr)
 	}
-	if mergedAgain.Verbose != yamlConf.Verbose {
+	if mergedAgain.Verbose != (merged.Verbose || yamlConf.Verbose) {
 		t.Errorf("Wrong Verbose for merged config; got %v, want %v", mergedAgain.Verbose, yamlConf.Verbose)
 	}
 


### PR DESCRIPTION
This patch provides functionality for reading configuration from a yaml file, and supports dispatching alerts to multiple commands based on what `match_labels` are set in configuration for a command.

Resolves #20
Resolves #21