### PR TITLE
resolved alert signal feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ commands:
   - cmd: /bin/true
     max: 3
     ignore_resolved: true
+  - cmd: /bin/sleep
+    args: ["10s"]
+    resolved_signal: SIGUSR1
 ```
 
 |Parameter|Use|
@@ -99,9 +102,13 @@ commands:
 |`match_labels`|What alert labels you'd like to use, to determine if the command should be executed. **All** specified labels must match in order for the command to be executed. If `match_labels` isn't specified, the command will be executed for _all_ alerts.|
 |`notify_on_failure`|By default if any executed command returns a non-zero exit code, the caller (alertmanager) is notified with an HTTP 500 status code in the response. This will likely result in alertmanager considering the message a 'failure to notify' and re-sends the alert to am-executor. If this is not desired behaviour, set `nofity_on_failure` to `false`.|
 |`max`|The maximum instances of this command that can be running at the same time. A zero or negative value is interpreted as 'no limit'.|
-|`ignore_resolved`|By default when an alertmanager message indicating the alerts are 'resolved' is received, any commands matching the alarm are killed if they are still active. If this is not desired behaviour, set this to `true`.|
+|`ignore_resolved`|By default when an alertmanager message indicating the alerts are 'resolved' is received, any commands matching the alarm are sent a signal if they are still active. If this is not desired behaviour, set this to `true`.|
+|`resolved_signal`|Specify which signal to send to matching commands that are still running when the triggering alert is resolved. (default: SIGKILL)|
 
-In the above configuration example, `/bin/true` will be executed for all alerts, and `echo` will be executed when an alert has the labels `env="testing"` and `owner="me"`.
+In the above configuration example:
+* `echo` will be executed when an alert has the labels `env="testing"` and `owner="me"`, receives SIGKILL if triggering alarm resolves while it's still running. If the command fails, the source of the alert isn't notified.
+* `/bin/true` will be executed for all alerts, and doesn't receive a signal if triggering alarm resolves while running.
+* `/bin/sleep` is executed for all alerts, and receives SIGUSR1 signal if triggering alarm resolves while still running.
 
 ##### Creating TLS Certificates
 

--- a/chanmap/chanmap_test.go
+++ b/chanmap/chanmap_test.go
@@ -19,7 +19,7 @@ func TestChannel_Close(t *testing.T) {
 		t.Errorf("missing channel for key '%s'", testKey)
 	}
 
-	go func() {c.ch <- struct{}{}}()
+	go func() { c.ch <- struct{}{} }()
 	_, ok = <-c.ch
 	if !ok {
 		t.Errorf("channel is closed when it should be open for key '%s'", testKey)
@@ -64,7 +64,7 @@ func TestChannelMap_Close(t *testing.T) {
 		t.Errorf("missing channel for key '%s'", testKey)
 	}
 
-	go func() {c.ch <- struct{}{}}()
+	go func() { c.ch <- struct{}{} }()
 	_, ok = <-c.ch
 	if !ok {
 		t.Errorf("channel is closed when it should be open for key '%s'", testKey)

--- a/config.go
+++ b/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
+	"log"
 )
 
 const (
@@ -92,6 +93,18 @@ func readCli() (*Config, error) {
 		file, err = readConfigFile(configFile)
 		if err != nil {
 			return nil, err
+		}
+	}
+
+	// Check that the commands specify resolved_signal values that we can parse
+	for i, cmd := range file.Commands {
+		_, err := cmd.ParseSignal()
+		if err != nil {
+			return nil, fmt.Errorf("Invalid resolved_signal specified for command %q at index %d: %w", cmd, i, err)
+		}
+
+		if cmd.IgnoreResolved != nil && *cmd.IgnoreResolved {
+			log.Printf("Warning: command %q at index %d specifies a resolved_signal, and also specifies to ignore resolved alert. The signal won't be used.", cmd, i)
 		}
 	}
 

--- a/config_test.go
+++ b/config_test.go
@@ -98,6 +98,7 @@ commands:
       "env": "testing"
       "owner": "me"
     notify_on_failure: false
+    resolved_signal: sigusr2
   - cmd: /bin/true
     match_labels:
       "beep": "boop"
@@ -147,6 +148,7 @@ commands:
 					"owner": "me",
 				},
 				NotifyOnFailure: &alsoFalse,
+				ResolvedSig:     "sigusr2",
 			},
 			shouldNotify:         false,
 			shouldIgnoreResolved: false,
@@ -166,13 +168,20 @@ commands:
 
 	for i, tc := range cases {
 		if !c.Commands[i].Equal(tc.cmd) {
-			t.Errorf("Commands not equal; '%s' and '%s'", c.Commands[i], tc.cmd.String())
+			t.Errorf("Commands not equal; %q and %q", c.Commands[i], tc.cmd.String())
 		}
 		if c.Commands[i].ShouldNotify() != tc.shouldNotify {
-			t.Errorf("Wrong NotifyOnFailure value for '%s'; got %v, want %v", c.Commands[i].String(), c.Commands[i].ShouldNotify(), tc.shouldNotify)
+			t.Errorf("Wrong NotifyOnFailure value for %q; got %v, want %v", c.Commands[i].String(), c.Commands[i].ShouldNotify(), tc.shouldNotify)
 		}
 		if c.Commands[i].ShouldIgnoreResolved() != tc.shouldIgnoreResolved {
-			t.Errorf("Wrong IgnoreResolved value for '%s'; got %v, want %v", c.Commands[i].String(), c.Commands[i].ShouldIgnoreResolved(), tc.shouldIgnoreResolved)
+			t.Errorf("Wrong IgnoreResolved value for %q; got %v, want %v", c.Commands[i].String(), c.Commands[i].ShouldIgnoreResolved(), tc.shouldIgnoreResolved)
+		}
+		if c.Commands[i].ResolvedSig != tc.cmd.ResolvedSig {
+			t.Errorf("Wrong ResolvedSig value for %q; got %s, want %s", c.Commands[i].String(), c.Commands[i].ResolvedSig, tc.cmd.ResolvedSig)
+		}
+		_, err := c.Commands[i].ParseSignal()
+		if err != nil {
+			t.Fatalf("Failed to convert command %q ResolvedSig value %s to signal: %v", c.Commands[i].String(), c.Commands[i].ResolvedSig, err)
 		}
 	}
 }

--- a/examples/executor.yml
+++ b/examples/executor.yml
@@ -16,10 +16,13 @@ commands:
     # Set to false to prevent non-zero exit codes from this command, from notifying alertmanager that the command failed.
     # Notifying alertmanager (HTTP 500) is likely to re-dispatch the alarm back to am-executor.
     notify_on_failure: false
+    # Send a SIGUSR1 signal to the process if it's still running when the triggering alert resolves.
+    # Default signal when not specified is SIGKILL.
+    resolved_signal: SIGUSR1
   # This command matches every alert
   - cmd: /bin/true
     # Maximum instances of this command that can be running at the same time.
     max: 3
-    # Don't interrupt command if a matching 'resolved' message is
+    # Don't signal command if a matching 'resolved' message is
     # sent from alertmanager while this command is still running.
     ignore_resolved: true


### PR DESCRIPTION
This patch adds the `resolved_signal` config item to command definitions. It allows the user to specify what signal is sent to running commands if a triggering alert resolves while it's still running.

The signal can be specified by its text name or as an integer value (still as string type in yaml config). The default signal sent remains `SIGKILL`.

Resolves #37 

**Incompatibility warning**

The `am_executor_killed_total` was renamed to `am_executor_signalled_total`. If we want to keep the existing `killed` metric, I'd add code to track that separately, and define which signals should be considered 'kill' signals (SIGKILL, SIGTERM, SIGINT?).

If we're ok with the rename, I can bump the major revision number when creating a tag for this patch once merged.