### PR TITLE
Add official Dockerfile, build official images to GitHub Packages

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,55 @@
+name: Docker image
+
+on: push
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Get the release channel
+        id: get_channel
+        shell: bash
+        run: |
+          if [[ "$GITHUB_REF" == 'refs/heads/master' ]]; then
+            echo ::set-output name=channel::"latest"
+            echo ::set-output name=version::master_${GITHUB_SHA::6}
+          elif [[ "$GITHUB_REF" == "refs/heads/"* ]]; then
+            echo ::set-output name=version::${GITHUB_REF/refs\/heads\//}_${GITHUB_SHA::6}
+          elif [[ "$GITHUB_REF" == "refs/tags/"* ]]; then
+            echo ::set-output name=channel::${GITHUB_REF/refs\/tags\//}
+          fi
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ steps.get_channel.outputs.channel }}
+            type=raw,value=${{ steps.get_channel.outputs.version }}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:1.17-alpine as builder
+
+WORKDIR /app
+
+COPY go.mod ./
+COPY go.sum ./
+RUN go mod download
+
+COPY *.go ./
+COPY chanmap ./chanmap
+COPY countermap ./countermap
+RUN go build
+
+FROM alpine:latest
+COPY --from=builder /app/prometheus-am-executor /prometheus-am-executor
+EXPOSE 8080
+ENTRYPOINT [ "/prometheus-am-executor" ]


### PR DESCRIPTION
There are 15 unofficial Docker images on DockerHub, so clearly there's demand for an image. All of them are either wildly out of date or do not publish their Dockerfile though, which is sub-optimal.

This PR adds a simple official Dockerfile and automated build action. An example of the automated build and an image it procudes can be seen in the fork where I'm proposing the merge from: https://ghcr.io/artanicus/prometheus-am-executor

Pushes to the `master` branch will tag the images with `latest`, all pushes to all branches are tagged with `branch_name-6-digit-hash-from-commit` and any git tags are tagged as-is. So for example a release tagged as `1.0` would result in an image: `ghcr.io/imgix/prometheus-am-executor:1.0`