### PR TITLE
Fixed a race condition when it is starting commands execution.

### DIFF
--- a/server.go
+++ b/server.go
@@ -269,12 +269,12 @@ func (s *Server) amFiring(amMsg *template.Data) []error {
 		go s.instrument(fingerprint, cmd, env, out)
 	}
 
-	// Wait for instrumentation, error collection to finish
 	go func() {
 		defer wg.Done()
 		collectWg.Wait()
 		close(errors)
 	}()
+	// Wait for instrumentation, error collection to finish
 	wg.Wait()
 
 	return allErrors

--- a/server.go
+++ b/server.go
@@ -3,12 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/imgix/prometheus-am-executor/chanmap"
-	"github.com/imgix/prometheus-am-executor/countermap"
-	"github.com/prometheus/alertmanager/template"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-	pm "github.com/prometheus/client_model/go"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -17,6 +11,13 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/imgix/prometheus-am-executor/chanmap"
+	"github.com/imgix/prometheus-am-executor/countermap"
+	"github.com/prometheus/alertmanager/template"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	pm "github.com/prometheus/client_model/go"
 )
 
 const (
@@ -221,11 +222,7 @@ func (s *Server) amFiring(amMsg *template.Data) []error {
 	var errors = make(chan error)
 	var allErrors = make([]error, 0)
 	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		collectWg.Wait()
-		close(errors)
-	}()
+
 	go func() {
 		defer wg.Done()
 		for err := range errors {
@@ -273,6 +270,11 @@ func (s *Server) amFiring(amMsg *template.Data) []error {
 	}
 
 	// Wait for instrumentation, error collection to finish
+	go func() {
+		defer wg.Done()
+		collectWg.Wait()
+		close(errors)
+	}()
 	wg.Wait()
 
 	return allErrors


### PR DESCRIPTION
Closes #49 

There are cases when the following error is occurred:
```go
goroutine 68 [running]:
main.(*Server).amFiring.func3({0xc00006ea80, 0xc00007ac00})
  /app/server.go:245 +0x1c5
created by main.(*Server).amFiring
  /app/server.go:270 +0x4a7
```

The patch solves the issue with starting the closing goroutine after running commands